### PR TITLE
Migrate to React@18

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,20 +3,15 @@ import ReactDOM from 'react-dom/client';
 import { App, store, persistState } from '@/app';
 import CssBaseline from '@mui/material/CssBaseline';
 import { Provider as StoreProvider } from 'react-redux';
-
-// mui/date
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-
-// react helmet
 import { HelmetProvider } from 'react-helmet-async';
-
-// fonts
 import '@fontsource/roboto/300.css';
 import '@fontsource/roboto/400.css';
 import '@fontsource/roboto/500.css';
 import '@fontsource/roboto/700.css';
 
+// subscribe to state changes, to persist state to localStorage
 store.subscribe(() => {
   persistState({
     tasks: store.getState().tasks,
@@ -24,6 +19,7 @@ store.subscribe(() => {
   });
 });
 
+// render app
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement
 );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,13 +1,7 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
-
-// styles
-import CssBaseline from '@mui/material/CssBaseline';
-
-// app
+import ReactDOM from 'react-dom/client';
 import { App, store, persistState } from '@/app';
-
-// store
+import CssBaseline from '@mui/material/CssBaseline';
 import { Provider as StoreProvider } from 'react-redux';
 
 // mui/date
@@ -30,7 +24,11 @@ store.subscribe(() => {
   });
 });
 
-ReactDOM.render(
+const root = ReactDOM.createRoot(
+  document.getElementById('root') as HTMLElement
+);
+
+root.render(
   <React.StrictMode>
     <HelmetProvider>
       <LocalizationProvider dateAdapter={AdapterDateFns}>
@@ -40,6 +38,5 @@ ReactDOM.render(
         </StoreProvider>
       </LocalizationProvider>
     </HelmetProvider>
-  </React.StrictMode>,
-  document.getElementById('root')
+  </React.StrictMode>
 );


### PR DESCRIPTION
Move from `ReactDOM.render()` to `createRoot()` api, in order to support React 18.

Closes #62 